### PR TITLE
fix: Fixed typo in feature summary stats graph

### DIFF
--- a/explainit/graphs/feature_stats_plots.py
+++ b/explainit/graphs/feature_stats_plots.py
@@ -106,7 +106,7 @@ def plot_feature_stats(
                 ),
                 marker_color="#48DD2D",
                 visible=False,
-                name="traininig",
+                name="reference",
             )
             trace3 = go.Histogram(
                 x=production_data[feature_name],
@@ -164,7 +164,7 @@ def plot_feature_stats(
                 go.Histogram(
                     x=reference_data[feature_name],
                     marker_color="#48DD2D",
-                    name="traininig",
+                    name="reference",
                 )
             )
             fig.add_trace(


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the typo in `feature summary` stats graph.

**Which issue(s) this PR fixes**:

Fixes #
[#21](https://github.com/katonic-dev/explainit/issues/21)