### PR TITLE
chore: Add Unique threshold param, doc-strings

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,7 +47,7 @@ In order to Initialize the dash application, you need to pass following paramete
 - `reference_data`: Reference dataset (pandas dataframe)
 - `production_data`: Production dataset (pandas dataframe)
 - `target_col_name`: Target column name
-- `target_col_type`: Target column nype (`"num"`: Numerical or `"cat"`: Categorical)
+- `target_col_type`: Target column type (`"num"`: Numerical or `"cat"`: Categorical)
 - `datetime_col_name`: Optional datetime column name (default: None)
 - `host`: Optional host address where you want to deploy/run the app eg: `"127.0.0.1"` or `"localhost"` (default: `"0.0.0.0"`)
 - `port`: Optional port where you want to deploy/run the app eg: `"8000"` (default: `"8050"`)

--- a/explainit/app.py
+++ b/explainit/app.py
@@ -75,6 +75,7 @@ def build(
     target_col_name: str,
     target_col_type: str,
     datetime_col_name: Optional[str] = "",
+    unique_threshold: Optional[int] = 15,
     host: str = "0.0.0.0",
     port: int = 8050,
 ):
@@ -124,7 +125,7 @@ def build(
     list(
         map(
             lambda x: cat_feature_names.append(x)
-            if reference_data[x].nunique() <= 15
+            if reference_data[x].nunique() <= unique_threshold
             else num_feature_names.append(x),
             cols,
         )

--- a/explainit/app.py
+++ b/explainit/app.py
@@ -79,6 +79,22 @@ def build(
     host: str = "0.0.0.0",
     port: int = 8050,
 ):
+    """
+    Creates and Run the ExplainIT Drift Detection, Data Quality Management Dash Application.
+
+    Args:
+        reference_data (DataFrame): Reference or Training dataset whom which you want to compare with.
+        production_data (DataFrame): Production or Inference dataset which comes from the user and compare with reference.
+        target_col_name (str): Target or Label name.
+        target_col_type (str): Target or Label type (`"num"`: Numerical or `"cat"`: Categorical).
+        datetime_col_name (str): Datetime column name (default: None).
+        unique_threshold (int): Unique value threshold to separate `"Numerical"` and `"Categorical"` features (default: 15).
+        host (str): Host address where you want to deploy/run the app eg: `"127.0.0.1"` or `"localhost"` (default: `"0.0.0.0"`).
+        port (int): Port where you want to deploy/run the app eg: `"8000"` (default: `"8050"`).
+
+    Return:
+        Returns the app instance with app url.
+    """
     app = dash.Dash(
         __name__,
         url_base_pathname=os.getenv("ROUTE") or "/",

--- a/explainit/correlations/correlations.py
+++ b/explainit/correlations/correlations.py
@@ -29,8 +29,9 @@ def select_features_for_corr(
             unique values;
         - for kramer_v correlation matrix, we select categorical features which have > 1 unique values.
     Args:
-        reference_features_stats: all features data quality metrics.
-        target_name: name of target column.
+        num_feats: all numeric features
+        cat_feats: all categorical features
+        ref_feat_stats: all features data quality metrics.
     Returns:
         num_for_corr: list of feature names for pearson, spearman, and kendall correlation matrices.
         cat_for_corr: list of feature names for kramer_v correlation matrix.


### PR DESCRIPTION
**What this PR does / why we need it**:
This issue needed to fix the static threshold for `num`, `cat` features separation, doc-strings for `build` function.

**Which issue(s) this PR fixes**:
This PR Adds the unique value threshold parameter, doc-string in `build` function, fixed typo in `getting-started.md` file and updates the doc-string in `correlation.py` module inside correlation folder.

Fixes https://github.com/katonic-dev/explainit/issues/35
